### PR TITLE
Add asset symlinks in page directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,5 +47,7 @@ YouTube videos (downloaded through `yt-dlp`) under `_assets/<host>/...`.
   whose name combines a slugified label and a short hash of the API path.
 - All assets are stored once under `_assets/<host>/...` and referenced from the
   generated `content_manifest.json` file.
+- Each page directory also contains symlinks to the assets it references so
+  they are easy to discover when browsing the exported folder tree.
 - The tool respects the TouchPros JSON API but gracefully falls back to parsing
   HTML fragments when the API returns pre-rendered markup.


### PR DESCRIPTION
## Summary
- create symlinks for downloaded assets inside each page directory and record their locations in the manifest
- add helper utilities to manage symlink naming and creation while reusing the shared asset store
- document the new symlink behavior in the README

## Testing
- python -m compileall touchpros_scraper.py

------
https://chatgpt.com/codex/tasks/task_e_68cdc280382c832c80d9f45434759ca3